### PR TITLE
Import Workflow Refinements (and more)

### DIFF
--- a/src/main/java/de/uoc/dh/idh/autodone/AutodoneApplication.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/AutodoneApplication.java
@@ -30,8 +30,6 @@ public class AutodoneApplication extends SpringApplication {
 		new AutodoneApplication().run(args);
 	}
 
-	//
-
 	public AutodoneApplication() {
 		super(AutodoneApplication.class);
 	}

--- a/src/main/java/de/uoc/dh/idh/autodone/config/AutodoneConfig.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/config/AutodoneConfig.java
@@ -7,7 +7,7 @@ import java.util.List;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration()
-@SuppressWarnings("unchecked")
+@SuppressWarnings("all")
 public class AutodoneConfig {
 
 	public static final List<String> AUTODONE_IMPORT_DATE;
@@ -22,7 +22,13 @@ public class AutodoneConfig {
 
 	public static final String AUTODONE_IMPORT_SNIP;
 
+	public static final String AUTODONE_IMG_FORMAT;
+
 	//
+
+	public static final int AUTODONE_IMG_SIZE_X;
+
+	public static final int AUTODONE_IMG_SIZE_Y;
 
 	public static final int AUTODONE_PAGINATION;
 
@@ -39,6 +45,10 @@ public class AutodoneConfig {
 
 		AUTODONE_IMPORT_SKIP = getEnvironment().getProperty("autodone.import.skip", String.class);
 		AUTODONE_IMPORT_SNIP = getEnvironment().getProperty("autodone.import.snip", String.class);
+		AUTODONE_IMG_FORMAT = getEnvironment().getProperty("autodone.img.format", String.class);
+
+		AUTODONE_IMG_SIZE_X = getEnvironment().getProperty("autodone.img.size.x", int.class);
+		AUTODONE_IMG_SIZE_Y = getEnvironment().getProperty("autodone.img.size.y", int.class);
 
 		AUTODONE_PAGINATION = getEnvironment().getProperty("autodone.pagination", int.class);
 		AUTODONE_SCHEDULING = getEnvironment().getProperty("autodone.scheduling", int.class);

--- a/src/main/java/de/uoc/dh/idh/autodone/config/ControllerConfig.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/config/ControllerConfig.java
@@ -16,11 +16,7 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
 @Configuration()
 public class ControllerConfig {
 
-	public static final List<String> paths;
-
-	static {
-		paths = new ArrayList<>();
-	}
+	public static final List<String> paths = new ArrayList<>();
 
 	//
 

--- a/src/main/java/de/uoc/dh/idh/autodone/config/SecurityConfig.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/config/SecurityConfig.java
@@ -26,6 +26,8 @@ public class SecurityConfig {
 
 	public static final String SCHEME;
 
+	//
+
 	static {
 		var rootPattern = defaultInstance.parse(DEFAULT_FILTER_PROCESSES_URI);
 		var pathPattern = defaultInstance.parse("{" + DEFAULT_REGISTRATION_ID_URI_VARIABLE_NAME + "}");
@@ -47,13 +49,10 @@ public class SecurityConfig {
 	@Bean()
 	public SecurityFilterChain securityFilterChain(ClientRepository repository, HttpSecurity http) throws Exception {
 		http.authorizeHttpRequests((authorizeHttpRequests) -> {
-			for (var path : paths) {
-				authorizeHttpRequests.requestMatchers(path).permitAll();
-			}
-
 			authorizeHttpRequests.requestMatchers("/images/**").permitAll();
 			authorizeHttpRequests.requestMatchers("/webjars/**").permitAll();
 			authorizeHttpRequests.requestMatchers(DEFAULT_LOGIN_PAGE_URL).permitAll();
+			paths.forEach((path) -> authorizeHttpRequests.requestMatchers(path).permitAll());
 			authorizeHttpRequests.anyRequest().authenticated();
 		});
 

--- a/src/main/java/de/uoc/dh/idh/autodone/controller/ErrorController.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/controller/ErrorController.java
@@ -19,7 +19,7 @@ import jakarta.servlet.http.HttpServletResponse;
 public class ErrorController implements org.springframework.boot.web.servlet.error.ErrorController {
 
 	@Autowired()
-	ErrorAttributes errorAttributes;
+	private ErrorAttributes errorAttributes;
 
 	//
 

--- a/src/main/java/de/uoc/dh/idh/autodone/controller/GroupController.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/controller/GroupController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import de.uoc.dh.idh.autodone.entities.GroupEntity;
 import de.uoc.dh.idh.autodone.entities.StatusEntity;
 import de.uoc.dh.idh.autodone.services.GroupService;
-import de.uoc.dh.idh.autodone.services.StatusService;;;
+import de.uoc.dh.idh.autodone.services.StatusService;
 
 @Controller()
 @RequestMapping("/group")

--- a/src/main/java/de/uoc/dh/idh/autodone/services/GroupService.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/GroupService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 import de.uoc.dh.idh.autodone.base.BaseService;
 import de.uoc.dh.idh.autodone.entities.GroupEntity;
 import de.uoc.dh.idh.autodone.repositories.GroupRepository;
-import jakarta.transaction.Transactional;;
+import jakarta.transaction.Transactional;
 
 @Service()
 @Transactional()

--- a/src/main/java/de/uoc/dh/idh/autodone/services/TimerService.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/TimerService.java
@@ -28,17 +28,11 @@ import jakarta.transaction.Transactional;
 @Transactional()
 public class TimerService {
 
-	private final static Map<UUID, ScheduledFuture<MediaEntity>> scheduledMedia;
+	private final static Map<UUID, ScheduledFuture<MediaEntity>> scheduledMedia = new HashMap<>();
 
-	private final static Map<UUID, ScheduledFuture<StatusEntity>> scheduledStatus;
+	private final static Map<UUID, ScheduledFuture<StatusEntity>> scheduledStatus = new HashMap<>();
 
-	private final static ScheduledExecutorService scheduler;
-
-	static {
-		scheduledMedia = new HashMap<>();
-		scheduledStatus = new HashMap<>();
-		scheduler = newScheduledThreadPool(AUTODONE_THREADPOOL);
-	}
+	private final static ScheduledExecutorService scheduler = newScheduledThreadPool(AUTODONE_THREADPOOL);
 
 	//
 

--- a/src/main/java/de/uoc/dh/idh/autodone/utils/DateTimeUtils.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/utils/DateTimeUtils.java
@@ -4,14 +4,10 @@ import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMPORT_DATE;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMPORT_DAYS;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMPORT_TIME;
 import static java.time.LocalDateTime.ofInstant;
-import static java.time.LocalTime.MAX;
-import static java.time.LocalTime.MIN;
-import static java.time.LocalTime.ofSecondOfDay;
 import static java.time.Year.now;
 import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.of;
 import static java.time.format.DateTimeFormatter.ofPattern;
-import static java.util.concurrent.ThreadLocalRandom.current;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -64,10 +60,6 @@ public class DateTimeUtils {
 	//
 
 	public LocalTime parseTime(String time) {
-		if (time.isEmpty()) {
-			return ofSecondOfDay(current().nextInt(MIN.toSecondOfDay(), MAX.toSecondOfDay()));
-		}
-
 		for (var format : AUTODONE_IMPORT_TIME) {
 			try {
 				return LocalTime.parse(time, ofPattern(format));

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -18,6 +18,10 @@ autodone.import.time=HH:mm:ss,HH:mm,H:mm,H:mm:ss
 autodone.import.skip=^(#|Dat(e|um)).*$
 autodone.import.snip=\ *\\t\ *
 
+autodone.img.format=png
+autodone.img.size.x=512
+autodone.img.size.y=512
+
 autodone.pagination=20
 autodone.scheduling=30
 autodone.threadpool=5

--- a/src/main/resources/templates/elements/head.html
+++ b/src/main/resources/templates/elements/head.html
@@ -31,7 +31,7 @@
     }
 
     textarea.form-control {
-      min-height: 7.25rem !important;
+      min-height: 7.5rem !important;
     }
 
     .accordion-footer {
@@ -64,12 +64,12 @@
     })();
 
     document.addEventListener("DOMContentLoaded", () => {
-      const data = document.querySelectorAll('[data-confirm]');
-      data.forEach((node) => node.onclick = () => confirm('Are You sure?'));
+      document.querySelectorAll('.btn').forEach((node) => {
+        node.onclick = () => setTimeout(() => node.disabled = true);
+      });
 
-      const href = document.querySelectorAll('[href^="data:image"]');
-      href.forEach((node) => node.onclick = () => {
-        window.open().document.write(`<img src="${node.href}">`);
+      document.querySelectorAll('[data-confirm]').forEach((node) => {
+        node.onclick = () => confirm('Are You sure?');
       });
     });
   </script>

--- a/src/main/resources/templates/entity/import.html
+++ b/src/main/resources/templates/entity/import.html
@@ -24,10 +24,11 @@
           </div>
         </div>
       </div>
-      <div th:if="${exceptions.size()}" class="accordion-item">
+      <div th:if="${errors.size()}" class="accordion-item">
         <div class="accordion-header">
           <button class="accordion-button collapsed fw-bold" data-bs-target="#fold-2" data-bs-toggle="collapse">
             Import Errors
+            <th:block th:text="|(${errors.size()})|" />
           </button>
         </div>
         <div class="accordion-collapse collapse" id="fold-2" data-bs-parent="#accordion">
@@ -41,7 +42,37 @@
                   </tr>
                 </thead>
                 <tbody>
-                  <th:block th:each="exception : ${exceptions}">
+                  <th:block th:each="exception : ${errors}">
+                    <tr th:each="message : ${exception.value}">
+                      <td th:text="${exception.key}" class="text-end"></td>
+                      <td th:text="${message}"></td>
+                    </tr>
+                  </th:block>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div th:if="${alerts.size()}" class="accordion-item">
+        <div class="accordion-header">
+          <button class="accordion-button collapsed fw-bold" data-bs-target="#fold-3" data-bs-toggle="collapse">
+            Import Alerts
+            <th:block th:text="|(${alerts.size()})|" />
+          </button>
+        </div>
+        <div class="accordion-collapse collapse" id="fold-3" data-bs-parent="#accordion">
+          <div class="accordion-body p-0">
+            <div class="table-responsive">
+              <table class="table m-0">
+                <thead>
+                  <tr>
+                    <th class="text-end">Line</th>
+                    <th>Alert</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <th:block th:each="exception : ${alerts}">
                     <tr th:each="message : ${exception.value}">
                       <td th:text="${exception.key}" class="text-end"></td>
                       <td th:text="${message}"></td>
@@ -64,15 +95,13 @@
               <th>Status</th>
               <th>Date (UTC)</th>
               <th class="text-end">Media</th>
-              <th class="text-end">Errors</th>
             </tr>
           </thead>
           <tbody>
-            <tr th:each="status : ${page}" th:object="${status}">
-              <td th:text="*{status}"></td>
-              <td th:text="*{date}"></td>
-              <td th:text="*{media.size()}" class="text-end"></td>
-              <td th:text="*{exceptions.size()}" class="text-end"></td>
+            <tr th:classappend="${status.exceptions.size()} ? 'table-warning'" th:each="status : ${page}">
+              <td th:text="${status.status}"></td>
+              <td th:text="${status.date}"></td>
+              <td th:text="${status.media.size()}" class="text-end"></td>
             </tr>
           </tbody>
         </table>

--- a/src/main/resources/templates/pages/about.html
+++ b/src/main/resources/templates/pages/about.html
@@ -6,7 +6,31 @@
 <body class="h-100 d-flex flex-column">
   <th:block th:insert="~{elements/navbar}" />
 
-  <main class="flex-grow-1 container"></main>
+  <main class="flex-grow-1 container">
+    <h1>About autodone</h1>
+
+    <p class="lead">
+      <strong>autodone</strong> is a service for the automated, time-controlled
+      publication of status updates on any Mastodon instance. The codebase is
+      <a href="https://github.com/dh-cologne/autodone">developed under a free
+      license</a> by the <a href="https://dh.uni-koeln.de">Department of Digital
+      Humanities</a> at the <a href="https://www.uni-koeln.de">University of
+      Cologne</a> and is open to all interested users.
+    </p>
+
+    <p class="lead">
+      Special features of the service include the ability to upload content in
+      tabular format (tsv files) and the ability to publish posts as a thread.
+      In addition to these basic functionalities, more features will be
+      developed in the future.
+    </p>
+
+    <p class="lead">
+      <strong>autodone</strong> replaces <strong>autoChirp</strong>, which
+      offered the same functionality for Twitter before the Twitter API and
+      Twitter itself was massively restricted regarding free and ethical usage.
+    </p>
+  </main>
 
   <th:block th:insert="~{elements/navend}" />
 </body>

--- a/src/main/resources/templates/pages/usage.html
+++ b/src/main/resources/templates/pages/usage.html
@@ -6,7 +6,13 @@
 <body class="h-100 d-flex flex-column">
   <th:block th:insert="~{elements/navbar}" />
 
-  <main class="flex-grow-1 container"></main>
+  <main class="flex-grow-1 container">
+    <h1>Usage Instructions</h1>
+
+    <p class="lead">
+      Usage instructions will follow soon.
+    </p>
+  </main>
 
   <th:block th:insert="~{elements/navend}" />
 </body>

--- a/src/main/resources/templates/tables/status.html
+++ b/src/main/resources/templates/tables/status.html
@@ -2,6 +2,7 @@
   <table class="table align-middle m-0">
     <thead>
       <tr>
+        <th th:if="${#path} == '/status'">Group</th>
         <th>Status</th>
         <th>Date (UTC)</th>
         <th class="text-center">Scheduling</th>
@@ -11,6 +12,7 @@
     </thead>
     <tbody>
       <tr th:each="status : ${page}" th:object="${status}">
+        <td th:if="${#path} == '/status'" th:text="*{#strings.abbreviate(group.name, 50)}"></td>
         <td th:text="*{status}"></td>
         <td th:text="*{date}"></td>
         <td class="text-center">


### PR DESCRIPTION
This pull request refines the tsv-import workflow by distinguishing between errors (lines which cannot be imported) and alerts (lines which will be imported, but are modified to suit the database structure). This mainly refers to trimming text content if it's too long to be published (currently the default Mastodon status length of 500 characters) and scaling images which are larger than 1024000 byte.

Furthermore some refinements were made regarding the codestyle and some template content was added.