### PR TITLE
Miscellaneous UI Fixes

### DIFF
--- a/src/main/java/de/uoc/dh/idh/autodone/utils/ObjectUtils.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/utils/ObjectUtils.java
@@ -102,7 +102,7 @@ public class ObjectUtils {
 
 	private ObjectUtils(ConversionService conversionService) {
 		ObjectUtils.conversionService = conversionService;
-		ObjectUtils.stringTrimmer = new StringTrimmerEditor(true);
+		ObjectUtils.stringTrimmer = new StringTrimmerEditor("\r", true);
 	}
 
 }

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -39,7 +39,7 @@ mastodon.api.apps=${mastodon.api}/v1/apps
 # https://docs.joinmastodon.org/methods/instance
 mastodon.api.instance=${mastodon.api}/v2/instance
 
-# https://docs.joinmastodon.org/methods/statuses
+# https://docs.joinmastodon.org/methods/media
 mastodon.api.media=${mastodon.api}/v2/media
 
 # https://docs.joinmastodon.org/methods/statuses

--- a/src/main/resources/templates/elements/head.html
+++ b/src/main/resources/templates/elements/head.html
@@ -64,12 +64,12 @@
     })();
 
     document.addEventListener("DOMContentLoaded", () => {
-      document.querySelectorAll('form .btn').forEach((node) => {
-        node.onclick = () => setTimeout(() => node.disabled = node.form.checkValidity());
+      document.querySelectorAll('form').forEach((form) => form.onsubmit = () => {
+        setTimeout(() => form.querySelectorAll('.btn').forEach((button) => button.disabled = true));
       });
 
-      document.querySelectorAll('[data-confirm]').forEach((node) => {
-        node.onclick = () => confirm('Are You sure?');
+      document.querySelectorAll('.btn[name=_method][value=delete]').forEach((button) => {
+        button.onclick = () => confirm('Permanently delete this entry?');
       });
     });
   </script>

--- a/src/main/resources/templates/elements/head.html
+++ b/src/main/resources/templates/elements/head.html
@@ -64,8 +64,8 @@
     })();
 
     document.addEventListener("DOMContentLoaded", () => {
-      document.querySelectorAll('.btn').forEach((node) => {
-        node.onclick = () => setTimeout(() => node.disabled = true);
+      document.querySelectorAll('form .btn').forEach((node) => {
+        node.onclick = () => setTimeout(() => node.disabled = node.form.checkValidity());
       });
 
       document.querySelectorAll('[data-confirm]').forEach((node) => {

--- a/src/main/resources/templates/elements/navbar.html
+++ b/src/main/resources/templates/elements/navbar.html
@@ -47,7 +47,7 @@
               Media Dashboard
             </a>
             <hr class="dropdown-divider">
-            <form th:action="@{/logout}" class="m-0" method="post">
+            <form th:action="@{/logout}" th:method="post" class="m-0">
               <button class="dropdown-item">Logout</button>
             </form>
           </div>

--- a/src/main/resources/templates/entities/server.html
+++ b/src/main/resources/templates/entities/server.html
@@ -38,7 +38,7 @@
           </ul>
         </div>
         <div class="card-footer d-flex justify-content-end">
-          <button class="btn btn-outline-primary" type="submit">Proceed</button>
+          <button class="btn btn-outline-primary">Proceed</button>
         </div>
       </div>
     </form>

--- a/src/main/resources/templates/forms/group.html
+++ b/src/main/resources/templates/forms/group.html
@@ -39,7 +39,7 @@
     <button th:text="*{uuid} ? 'Update' : 'Create'" class="btn btn-outline-primary"></button>
     <th:block th:if="*{uuid}">
       <button class="btn btn-outline-secondary me-1" type="reset">Reset</button>
-      <button data-confirm class="btn btn-outline-danger me-1" name="_method" value="delete">Delete</button>
+      <button class="btn btn-outline-danger me-1" name="_method" value="delete">Delete</button>
     </th:block>
   </div>
 </form>

--- a/src/main/resources/templates/forms/media.html
+++ b/src/main/resources/templates/forms/media.html
@@ -39,7 +39,7 @@
         <div th:classappend="'col-md-' + (*{uuid} ? 12 : 6)" class="mb-3">
           <label class="form-label fw-bold" for="description">Media Description</label>
           <div class="form-floating">
-            <input placeholder th:field="*{description}" class="form-control">
+            <textarea placeholder th:field="*{description}" class="form-control" maxlength="1500"></textarea>
             <label class="form-label">Description for the attached Media</label>
           </div>
         </div>

--- a/src/main/resources/templates/forms/media.html
+++ b/src/main/resources/templates/forms/media.html
@@ -50,7 +50,7 @@
     <button th:text="*{uuid} ? 'Update' : 'Create'" class="btn btn-outline-primary"></button>
     <th:block th:if="*{uuid}">
       <button class="btn btn-outline-secondary me-1" type="reset">Reset</button>
-      <button data-confirm class="btn btn-outline-danger me-1" name="_method" value="delete">Delete</button>
+      <button class="btn btn-outline-danger me-1" name="_method" value="delete">Delete</button>
     </th:block>
   </div>
 </form>

--- a/src/main/resources/templates/forms/status.html
+++ b/src/main/resources/templates/forms/status.html
@@ -31,7 +31,7 @@
     <div class="col-md-6 mb-3">
       <label class="form-label fw-bold" for="status">Status Content</label>
       <div class="form-floating">
-        <textarea placeholder required th:field="*{status}" class="form-control"></textarea>
+        <textarea placeholder required th:field="*{status}" class="form-control" maxlength="500"></textarea>
         <label class="form-label">Content for the Status</label>
       </div>
     </div>

--- a/src/main/resources/templates/forms/status.html
+++ b/src/main/resources/templates/forms/status.html
@@ -40,7 +40,7 @@
     <button th:text="*{uuid} ? 'Update' : 'Create'" class="btn btn-outline-primary"></button>
     <th:block th:if="*{uuid}">
       <button class="btn btn-outline-secondary me-1" type="reset">Reset</button>
-      <button data-confirm class="btn btn-outline-danger me-1" name="_method" value="delete">Delete</button>
+      <button class="btn btn-outline-danger me-1" name="_method" value="delete">Delete</button>
     </th:block>
   </div>
 </form>

--- a/src/main/resources/templates/tables/group.html
+++ b/src/main/resources/templates/tables/group.html
@@ -29,9 +29,9 @@
           <a th:href="@{/group(uuid=*{uuid})}" class="btn btn-sm btn-outline-primary">
             <i class="bi bi-eye-fill"></i>
           </a>
-          <form th:action="@{/group}" th:method="delete" class="d-inline-block m-0">
+          <form th:action="@{/group}" th:method="post" class="d-inline-block m-0">
             <input th:value="*{uuid}" name="uuid" type="hidden">
-            <button data-confirm class="btn btn-sm btn-outline-danger">
+            <button class="btn btn-sm btn-outline-danger" name="_method" value="delete">
               <i class="bi bi-trash-fill"></i>
             </button>
           </form>

--- a/src/main/resources/templates/tables/media.html
+++ b/src/main/resources/templates/tables/media.html
@@ -16,9 +16,9 @@
             <i class="bi bi-list"></i>
           </a>
         </th:block>
-        <form th:action="@{/media}" th:method="delete" class="d-inline-block m-0">
+        <form th:action="@{/media}" th:method="post" class="d-inline-block m-0">
           <input th:value="*{uuid}" name="uuid" type="hidden">
-          <button data-confirm class="btn btn-sm btn-outline-danger">
+          <button class="btn btn-sm btn-outline-danger" name="_method" value="delete">
             <i class="bi bi-trash-fill"></i>
           </button>
         </form>

--- a/src/main/resources/templates/tables/status.html
+++ b/src/main/resources/templates/tables/status.html
@@ -32,9 +32,9 @@
               <i class="bi bi-list"></i>
             </a>
           </th:block>
-          <form th:action="@{/status}" th:method="delete" class="d-inline-block m-0">
+          <form th:action="@{/status}" th:method="post" class="d-inline-block m-0">
             <input th:value="*{uuid}" name="uuid" type="hidden">
-            <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Are You sure?')">
+            <button class="btn btn-sm btn-outline-danger" name="_method" value="delete">
               <i class="bi bi-trash-fill"></i>
             </button>
           </form>


### PR DESCRIPTION
This pull request fixes the following issues:
- hermesj#14  
This was caused by the client sending `\r\n` characters to represent line-breaks in textareas and solved by providing an additional parameter to the constructor of `StringTrimmerEditor`
- hermesj#13  
Simply replaced the `input` with a `textarea`
- **disabling of buttons upon no-op events**  
this was caused by a general disable-`onclick` handler and caused `reset` and `submit` buttons to be disabled, unconditionally, and fixed by using the `onsubmit` handler of the form instead