### PR TITLE
Fix breaking threads upon publication error

### DIFF
--- a/src/main/java/de/uoc/dh/idh/autodone/entities/StatusEntity.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/entities/StatusEntity.java
@@ -45,9 +45,6 @@ public class StatusEntity {
 	@Column()
 	public String id;
 
-	@Column()
-	public String inReplyToId;
-
 	@Column(nullable = false, length = 500)
 	public String status;
 

--- a/src/main/java/de/uoc/dh/idh/autodone/repositories/StatusRepository.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/repositories/StatusRepository.java
@@ -70,7 +70,7 @@ public interface StatusRepository extends BaseRepository<StatusEntity> {
 
 	//
 
-	public StatusEntity findTopByGroupAndDateAfterOrderByDate(
+	public StatusEntity findTopByGroupAndDateBeforeAndIdIsNotNullOrderByDateDesc(
 
 			GroupEntity group,
 


### PR DESCRIPTION
This pull request fixes threads breaking off at the first status publication error. While this will continue publishing scheduled status' as a thread, while just skipping status publication error, it introduces a minor time slippage due to a database lookup.