### PR TITLE
Fix Java heap memory exhaustion on startup

### DIFF
--- a/src/main/java/de/uoc/dh/idh/autodone/base/BaseEntity.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/base/BaseEntity.java
@@ -1,0 +1,9 @@
+package de.uoc.dh.idh.autodone.base;
+
+import java.util.UUID;
+
+public interface BaseEntity {
+
+	public UUID getUuid();
+
+}

--- a/src/main/java/de/uoc/dh/idh/autodone/base/BaseRepository.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/base/BaseRepository.java
@@ -8,4 +8,7 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 
 @NoRepositoryBean()
 public interface BaseRepository<T> extends CrudRepository<T, UUID>, PagingAndSortingRepository<T, UUID> {
+
+	public Iterable<BaseEntity> findAllBy();
+
 }

--- a/src/main/java/de/uoc/dh/idh/autodone/repositories/StatusRepository.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/repositories/StatusRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import de.uoc.dh.idh.autodone.base.BaseEntity;
 import de.uoc.dh.idh.autodone.base.BaseRepository;
 import de.uoc.dh.idh.autodone.entities.GroupEntity;
 import de.uoc.dh.idh.autodone.entities.StatusEntity;
@@ -28,7 +29,7 @@ public interface StatusRepository extends BaseRepository<StatusEntity> {
 
 	//
 
-	public Iterable<StatusEntity> findAllByDateAfterAndGroupEnabledTrueAndIdIsNull(
+	public Iterable<BaseEntity> findAllByDateAfterAndGroupEnabledTrueAndIdIsNull(
 
 			Instant date
 

--- a/src/main/java/de/uoc/dh/idh/autodone/services/MediaService.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/MediaService.java
@@ -35,6 +35,10 @@ public class MediaService extends BaseService<MediaEntity> {
 
 	//
 
+	public MediaEntity getAny(UUID uuid) {
+		return mediaRepository.findById(uuid).get();
+	}
+
 	public Page<MediaEntity> getPage(String page, String sort, StatusEntity status) {
 		return getPage(pageRequest(page, sort), status.media);
 	}
@@ -42,7 +46,7 @@ public class MediaService extends BaseService<MediaEntity> {
 	//
 
 	public MediaEntity publish(UUID uuid) {
-		return publish(mediaRepository.findById(uuid).get());
+		return publish(getAny(uuid));
 	}
 
 	public MediaEntity publish(MediaEntity media) {

--- a/src/main/java/de/uoc/dh/idh/autodone/services/StatusService.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/StatusService.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import de.uoc.dh.idh.autodone.base.BaseEntity;
 import de.uoc.dh.idh.autodone.base.BaseService;
 import de.uoc.dh.idh.autodone.entities.GroupEntity;
 import de.uoc.dh.idh.autodone.entities.StatusEntity;
@@ -35,8 +36,12 @@ public class StatusService extends BaseService<StatusEntity> {
 
 	//
 
-	public Iterable<StatusEntity> getAll(Instant date) {
+	public Iterable<BaseEntity> getAll(Instant date) {
 		return statusRepository.findAllByDateAfterAndGroupEnabledTrueAndIdIsNull(date);
+	}
+
+	public StatusEntity getAny(UUID uuid) {
+		return statusRepository.findById(uuid).get();
 	}
 
 	public Page<StatusEntity> getPage(String page, String sort, GroupEntity group) {
@@ -46,7 +51,7 @@ public class StatusService extends BaseService<StatusEntity> {
 	//
 
 	public StatusEntity publish(UUID uuid) {
-		return publish(statusRepository.findById(uuid).get());
+		return publish(getAny(uuid));
 	}
 
 	public StatusEntity publish(StatusEntity status) {


### PR DESCRIPTION
This pull request resolves a Java heap memory exhaustion error which occurres on startup and is triggered by database growth. The solution employs a [Spring Data JPA Projection](https://docs.spring.io/spring-data/jpa/reference/repositories/projections.html) to fetch only the UUIDs of entities needed for the creation of the internal `ScheduledThreadPool`. Those UUIDs are used to fetch and schedule the publication of each `StatusEntity` individually. Furhtermore, by only passing the UUID (opposed to the whole entity) into the `schedule` callback scope, garbage collection can occur for each entity, thereby resolving the Java heap memory exhaustion error.