### PR TITLE
Fix server column name in token entity unique constraint

### DIFF
--- a/src/main/java/de/uoc/dh/idh/autodone/entities/TokenEntity.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/entities/TokenEntity.java
@@ -23,7 +23,7 @@ import lombok.Data;
 @Data()
 @Entity()
 @JsonNaming(SnakeCaseStrategy.class)
-@Table(uniqueConstraints = { @UniqueConstraint(columnNames = { "server", "username" }) })
+@Table(uniqueConstraints = { @UniqueConstraint(columnNames = { "server_uuid", "username" }) })
 public class TokenEntity {
 
 	@Id()


### PR DESCRIPTION
The generated name of the server column of `token_entity` is `server_uuid`, not `server`. The unique constraint on the table should reflect this.

I ran into this problem when trying to create the necessary database tables for Autodone on a fresh PostgreSQL database. Hibernate tries to create the `token_entity` table using the following SQL:

```sql
CREATE TABLE token_entity (
    server_uuid UUID NOT NULL,
    uuid UUID NOT NULL,
    token varchar(255) NOT NULL,
    username varchar(255) NOT NULL,
    PRIMARY KEY (UUID),
    UNIQUE (server, username)
);
```

This obviously fails because the unique constraint refers to a column named `server` which doesn’t exist.