### PR TITLE
Rate limiting 

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 x-anchor:
   service: &service
     hostname: localhost
@@ -40,7 +38,7 @@ services:
 
   mastodon:
     <<: *service
-    image: bitnami/mastodon:4
+    image: bitnami/mastodon:4.2.9
     ports: [3000:3000]
     environment:
       <<: *environment

--- a/src/main/java/de/uoc/dh/idh/autodone/config/AutodoneConfig.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/config/AutodoneConfig.java
@@ -36,7 +36,11 @@ public class AutodoneConfig {
 
 	public static final int AUTODONE_THREADPOOL;
 
+	//
+	
 	public static final int AUTODONE_DOWNLOADRATELIMIT;
+
+	public static final int AUTODONE_DOWNLOADTHREADPOOL;
 
 	//
 
@@ -56,6 +60,7 @@ public class AutodoneConfig {
 		AUTODONE_SCHEDULING = getEnvironment().getProperty("autodone.scheduling", int.class);
 		AUTODONE_THREADPOOL = getEnvironment().getProperty("autodone.threadpool", int.class);
 		AUTODONE_DOWNLOADRATELIMIT = getEnvironment().getProperty("autodone.downloadratelimit", int.class);
+		AUTODONE_DOWNLOADTHREADPOOL = getEnvironment().getProperty("autodone.downloadthreadpool", int.class);
 	}
 
 }

--- a/src/main/java/de/uoc/dh/idh/autodone/config/AutodoneConfig.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/config/AutodoneConfig.java
@@ -36,6 +36,8 @@ public class AutodoneConfig {
 
 	public static final int AUTODONE_THREADPOOL;
 
+	public static final int AUTODONE_DOWNLOADRATELIMIT;
+
 	//
 
 	static {
@@ -53,6 +55,7 @@ public class AutodoneConfig {
 		AUTODONE_PAGINATION = getEnvironment().getProperty("autodone.pagination", int.class);
 		AUTODONE_SCHEDULING = getEnvironment().getProperty("autodone.scheduling", int.class);
 		AUTODONE_THREADPOOL = getEnvironment().getProperty("autodone.threadpool", int.class);
+		AUTODONE_DOWNLOADRATELIMIT = getEnvironment().getProperty("autodone.downloadratelimit", int.class);
 	}
 
 }

--- a/src/main/java/de/uoc/dh/idh/autodone/controller/ImportController.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/controller/ImportController.java
@@ -21,6 +21,8 @@ import org.springframework.web.multipart.MultipartFile;
 import de.uoc.dh.idh.autodone.entities.GroupEntity;
 import de.uoc.dh.idh.autodone.services.GroupService;
 import de.uoc.dh.idh.autodone.services.ImportService;
+import de.uoc.dh.idh.autodone.services.MediaDownloadQueue;
+import de.uoc.dh.idh.autodone.services.MediaDownloadTask;
 import de.uoc.dh.idh.autodone.services.StatusService;
 import jakarta.servlet.http.HttpSession;
 
@@ -39,6 +41,9 @@ public class ImportController {
 
 	@Autowired()
 	private StatusService statusService;
+
+	@Autowired()
+    private MediaDownloadQueue mediaDownloadQueue;
 
 	//
 
@@ -83,6 +88,14 @@ public class ImportController {
 			httpSession.removeAttribute("import");
 
 			var save = groupService.save(mapFields(form, group, FORCE));
+
+			System.out.println("Now adding media download tasks");
+			for (var status : save.status) {
+				if (status.media.size() > 0) {
+					mediaDownloadQueue.addTask(new MediaDownloadTask(status.media.get(0), status));
+				}
+			}
+
 			return "redirect:/group?uuid=" + save.uuid;
 		}
 	}

--- a/src/main/java/de/uoc/dh/idh/autodone/services/GroupService.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/GroupService.java
@@ -28,9 +28,6 @@ public class GroupService extends BaseService<GroupEntity> {
 	@Autowired()
 	private TokenService tokenService;
 
-	@Autowired
-    private MediaDownloadQueue mediaDownloadQueue;
-
 	//
 
 	public GroupEntity save(GroupEntity group) {

--- a/src/main/java/de/uoc/dh/idh/autodone/services/GroupService.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/GroupService.java
@@ -28,6 +28,9 @@ public class GroupService extends BaseService<GroupEntity> {
 	@Autowired()
 	private TokenService tokenService;
 
+	@Autowired
+    private MediaDownloadQueue mediaDownloadQueue;
+
 	//
 
 	public GroupEntity save(GroupEntity group) {

--- a/src/main/java/de/uoc/dh/idh/autodone/services/ImportService.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/ImportService.java
@@ -41,6 +41,9 @@ public class ImportService {
 	@Autowired()
 	private DateTimeUtils dateTimeUtils;
 
+	@Autowired
+    private MediaDownloadQueue mediaDownloadQueue;
+
 	//
 
 	public GroupEntity importGroup(InputStream inputStream) throws Exception {
@@ -114,20 +117,23 @@ public class ImportService {
 
 			if (columns.length > 3) {
 				try {
-					status.media.add(mapFields(of("status", status), importMedia(columns[3])));
+					System.out.println("Adding media download task for " + columns[3]);
+					mediaDownloadQueue.addTask(new MediaDownloadTask(columns[3], status, columns[4]));
 
-					if (status.media.get(0).description != null) {
-						status.exceptions.add(new ParseException("Image scaled down (4th column)", number));
-						status.media.get(0).description = null;
-					}
+					// status.media.add(mapFields(of("status", status), importMedia(columns[3])));
 
-					if (columns.length > 4) {
-						if (columns[4].length() > 1500) {
-							status.exceptions.add(new ParseException("Image caption too long (5th column)", number));
-						} else {
-							status.media.get(0).description = columns[4];
-						}
-					}
+					// if (status.media.get(0).description != null) {
+					// 	status.exceptions.add(new ParseException("Image scaled down (4th column)", number));
+					// 	status.media.get(0).description = null;
+					// }
+
+					// if (columns.length > 4) {
+					// 	if (columns[4].length() > 1500) {
+					// 		status.exceptions.add(new ParseException("Image caption too long (5th column)", number));
+					// 	} else {
+					// 		status.media.get(0).description = columns[4];
+					// 	}
+					// }
 				} catch (Exception exception) {
 					status.exceptions.add(new ParseException("Image not usable (4th column)", number));
 				}
@@ -139,41 +145,41 @@ public class ImportService {
 
 	//
 
-	public MediaEntity importMedia(String url) throws Exception {
-		var media = new MediaEntity();
-		var request = new URL(url).openConnection();
+	// public MediaEntity importMedia(String url) throws Exception {
+	// 	var media = new MediaEntity();
+	// 	var request = new URL(url).openConnection();
 
-		media.contentType = request.getContentType();
+	// 	media.contentType = request.getContentType();
 
-		if (request.getContentLength() < 1024000) {
-			media.file = request.getInputStream().readAllBytes();
-		} else {
-			var buffer = new ByteArrayOutputStream();
-			var source = read(request.getInputStream());
+	// 	if (request.getContentLength() < 1024000) {
+	// 		media.file = request.getInputStream().readAllBytes();
+	// 	} else {
+	// 		var buffer = new ByteArrayOutputStream();
+	// 		var source = read(request.getInputStream());
 
-			var scaleX = source.getWidth();
-			var scaleY = source.getHeight();
+	// 		var scaleX = source.getWidth();
+	// 		var scaleY = source.getHeight();
 
-			if (scaleX > AUTODONE_IMG_SIZE_X) {
-				scaleX = AUTODONE_IMG_SIZE_X;
-				scaleY = (scaleX * source.getHeight()) / source.getWidth();
-			}
+	// 		if (scaleX > AUTODONE_IMG_SIZE_X) {
+	// 			scaleX = AUTODONE_IMG_SIZE_X;
+	// 			scaleY = (scaleX * source.getHeight()) / source.getWidth();
+	// 		}
 
-			if (scaleY > AUTODONE_IMG_SIZE_Y) {
-				scaleY = AUTODONE_IMG_SIZE_Y;
-				scaleX = (scaleY * source.getWidth()) / source.getHeight();
-			}
+	// 		if (scaleY > AUTODONE_IMG_SIZE_Y) {
+	// 			scaleY = AUTODONE_IMG_SIZE_Y;
+	// 			scaleX = (scaleY * source.getWidth()) / source.getHeight();
+	// 		}
 
-			var target = new BufferedImage(scaleX, scaleY, TYPE_INT_ARGB);
-			var scaled = source.getScaledInstance(scaleX, scaleY, SCALE_FAST);
-			target.getGraphics().drawImage(scaled, 0, 0, null, null);
-			write(target, AUTODONE_IMG_FORMAT, buffer);
+	// 		var target = new BufferedImage(scaleX, scaleY, TYPE_INT_ARGB);
+	// 		var scaled = source.getScaledInstance(scaleX, scaleY, SCALE_FAST);
+	// 		target.getGraphics().drawImage(scaled, 0, 0, null, null);
+	// 		write(target, AUTODONE_IMG_FORMAT, buffer);
 
-			media.description = "Scaled down from original";
-			media.file = buffer.toByteArray();
-		}
+	// 		media.description = "Scaled down from original";
+	// 		media.file = buffer.toByteArray();
+	// 	}
 
-		return media;
-	}
+	// 	return media;
+	// }
 
 }

--- a/src/main/java/de/uoc/dh/idh/autodone/services/ImportService.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/ImportService.java
@@ -1,26 +1,16 @@
 package de.uoc.dh.idh.autodone.services;
 
-import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_FORMAT;
-import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_SIZE_X;
-import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_SIZE_Y;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMPORT_SKIP;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMPORT_SNIP;
 import static de.uoc.dh.idh.autodone.utils.ObjectUtils.mapFields;
-import static java.awt.Image.SCALE_FAST;
-import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
 import static java.time.Instant.now;
 import static java.time.LocalDateTime.ofInstant;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Map.of;
-import static javax.imageio.ImageIO.read;
-import static javax.imageio.ImageIO.write;
 
-import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URL;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -40,9 +30,6 @@ public class ImportService {
 
 	@Autowired()
 	private DateTimeUtils dateTimeUtils;
-
-	@Autowired
-    private MediaDownloadQueue mediaDownloadQueue;
 
 	//
 
@@ -117,23 +104,19 @@ public class ImportService {
 
 			if (columns.length > 3) {
 				try {
-					System.out.println("Adding media download task for " + columns[3]);
-					mediaDownloadQueue.addTask(new MediaDownloadTask(columns[3], status, columns[4]));
+					MediaEntity media = new MediaEntity();
+					media.url = columns[3];
 
-					// status.media.add(mapFields(of("status", status), importMedia(columns[3])));
+					if (columns.length > 4) {
+						if (columns[4].length() > 1500) {
+							status.exceptions.add(new ParseException("Image caption too long (5th column)", number));
+						} else {
+							media.description = columns[4];
+						}
+					}
 
-					// if (status.media.get(0).description != null) {
-					// 	status.exceptions.add(new ParseException("Image scaled down (4th column)", number));
-					// 	status.media.get(0).description = null;
-					// }
+					status.media.add(mapFields(of("status", status), media));
 
-					// if (columns.length > 4) {
-					// 	if (columns[4].length() > 1500) {
-					// 		status.exceptions.add(new ParseException("Image caption too long (5th column)", number));
-					// 	} else {
-					// 		status.media.get(0).description = columns[4];
-					// 	}
-					// }
 				} catch (Exception exception) {
 					status.exceptions.add(new ParseException("Image not usable (4th column)", number));
 				}
@@ -144,42 +127,4 @@ public class ImportService {
 	}
 
 	//
-
-	// public MediaEntity importMedia(String url) throws Exception {
-	// 	var media = new MediaEntity();
-	// 	var request = new URL(url).openConnection();
-
-	// 	media.contentType = request.getContentType();
-
-	// 	if (request.getContentLength() < 1024000) {
-	// 		media.file = request.getInputStream().readAllBytes();
-	// 	} else {
-	// 		var buffer = new ByteArrayOutputStream();
-	// 		var source = read(request.getInputStream());
-
-	// 		var scaleX = source.getWidth();
-	// 		var scaleY = source.getHeight();
-
-	// 		if (scaleX > AUTODONE_IMG_SIZE_X) {
-	// 			scaleX = AUTODONE_IMG_SIZE_X;
-	// 			scaleY = (scaleX * source.getHeight()) / source.getWidth();
-	// 		}
-
-	// 		if (scaleY > AUTODONE_IMG_SIZE_Y) {
-	// 			scaleY = AUTODONE_IMG_SIZE_Y;
-	// 			scaleX = (scaleY * source.getWidth()) / source.getHeight();
-	// 		}
-
-	// 		var target = new BufferedImage(scaleX, scaleY, TYPE_INT_ARGB);
-	// 		var scaled = source.getScaledInstance(scaleX, scaleY, SCALE_FAST);
-	// 		target.getGraphics().drawImage(scaled, 0, 0, null, null);
-	// 		write(target, AUTODONE_IMG_FORMAT, buffer);
-
-	// 		media.description = "Scaled down from original";
-	// 		media.file = buffer.toByteArray();
-	// 	}
-
-	// 	return media;
-	// }
-
 }

--- a/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadExecutor.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadExecutor.java
@@ -4,8 +4,6 @@ import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_FORMAT;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_SIZE_X;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_SIZE_Y;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_DOWNLOADRATELIMIT;
-import static de.uoc.dh.idh.autodone.utils.ObjectUtils.FORCE;
-import static de.uoc.dh.idh.autodone.utils.ObjectUtils.mapFields;
 
 import java.util.concurrent.PriorityBlockingQueue;
 
@@ -22,17 +20,14 @@ import org.springframework.stereotype.Component;
 
 import static java.awt.Image.SCALE_FAST;
 import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
-import static java.util.Map.of;
 import static javax.imageio.ImageIO.read;
 import static javax.imageio.ImageIO.write;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.net.URL;
-import java.text.ParseException;
 
 import de.uoc.dh.idh.autodone.entities.MediaEntity;
-import de.uoc.dh.idh.autodone.entities.StatusEntity;
 
 
 @Component
@@ -40,11 +35,11 @@ public class MediaDownloadExecutor {
     private final PriorityBlockingQueue<MediaDownloadTask> queue;
     private final ExecutorService executorService;
 
-    @Autowired
-    private StatusService statusService;
+    @Autowired()
+    private MediaService mediaService;
 
 
-    @Autowired
+    @Autowired()
     public MediaDownloadExecutor(MediaDownloadQueue queue) {
         this.queue = queue.getQueue();
         this.executorService = Executors.newFixedThreadPool(1);
@@ -64,34 +59,33 @@ public class MediaDownloadExecutor {
         try {
             System.out.println("Thread started");
             while (true) {
-                System.out.println("Attempting to take task from queue");
+                System.out.println("Taking task from queue:" + queue.size());
+                System.out.println("MediaDownloadExecutor queue instance: " + System.identityHashCode(queue));
                 MediaDownloadTask task = queue.take();
-                System.out.println("Took task from queue : " + task.getDescription());
+                System.out.println("Downloading media for Time" + task.getStatus().getDate());
+                MediaEntity downloadMedia = importMedia(task.getMedia().getUrl());
+                System.out.println("Finished download media: " + task.getMedia().getUrl());
+                System.out.println("Download media file: " + downloadMedia.file.length);
 
-                System.out.println("Processing task: " + task.getDescription());
+                System.out.println("Getting media from database: " + task.getMedia().getUuid().toString());
+                MediaEntity media = mediaService.getAny(task.getMedia().getUuid());
+                System.out.println("Got media from database: " + media.getUuid().toString());
 
-                StatusEntity status = task.getStatus();
+                media.file = downloadMedia.file;
 
-                status.media.add(mapFields(of("status", status), importMedia(task.getMedia())));
+                System.out.println("media file: " + media.file.length);
 
-                if (status.media.get(0).description != null) {
-                    // status.exceptions.add(new ParseException("Image scaled down (4th column)"));
-                    status.media.get(0).description = null;
+                media.contentType = downloadMedia.contentType;
+                if (downloadMedia.description != null) {
+                    media.description = media.description + " " + downloadMedia.description;
                 }
+                
+                mediaService.save(media);
+                System.out.println("Saved media: " + media.getUuid().toString());
 
-                if (task.getDescription() != null) {
-                    if (task.getDescription().length() > 1500) {
-                        // status.exceptions.add(new ParseException("Image caption too long (5th column)", number));
-                    } else {
-                        System.out.println("Setting description for media");
-                        status.media.get(0).description = task.getDescription();
-                    }
-                }
-
-                System.out.println("Added media to download for status " + status.getUuid());
-
-
+                System.out.println("Thread sleeping");
                 TimeUnit.MILLISECONDS.sleep(AUTODONE_DOWNLOADRATELIMIT);
+                System.out.println("Thread continue");
 
             }
         } catch (InterruptedException e) {
@@ -106,7 +100,7 @@ public class MediaDownloadExecutor {
 
     public MediaEntity importMedia(String url) {
         try {
-            System.out.println("Downloading media");
+            System.out.println("Downloading media: " + url);
             var media = new MediaEntity();
             var request = new URL(url).openConnection();
 
@@ -136,7 +130,7 @@ public class MediaDownloadExecutor {
                 target.getGraphics().drawImage(scaled, 0, 0, null, null);
                 write(target, AUTODONE_IMG_FORMAT, buffer);
 
-                media.description = "Scaled down from original";
+                media.description = "(Scaled down from original)";
                 media.file = buffer.toByteArray();
             }
 

--- a/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadExecutor.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadExecutor.java
@@ -1,0 +1,139 @@
+package de.uoc.dh.idh.autodone.services;
+
+import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_FORMAT;
+import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_SIZE_X;
+import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_SIZE_Y;
+import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_DOWNLOADRATELIMIT;
+import static de.uoc.dh.idh.autodone.utils.ObjectUtils.mapFields;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import static java.awt.Image.SCALE_FAST;
+import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
+import static java.util.Map.of;
+import static javax.imageio.ImageIO.read;
+import static javax.imageio.ImageIO.write;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.net.URL;
+import java.text.ParseException;
+import de.uoc.dh.idh.autodone.entities.MediaEntity;
+import de.uoc.dh.idh.autodone.entities.StatusEntity;
+
+
+
+
+@Component
+public class MediaDownloadExecutor {
+    private final MediaDownloadQueue queue;
+    private final ExecutorService executorService;
+    @Autowired()
+	private StatusService statusService;
+
+    @Autowired
+    public MediaDownloadExecutor(MediaDownloadQueue queue) {
+        this.queue = queue;
+        this.executorService = Executors.newFixedThreadPool(5); // Adjust thread count as needed
+        System.out.println("Created executor service with 5 threads");
+    }
+
+    @PostConstruct
+    public void start() {
+        for (int i = 0; i < ((ThreadPoolExecutor) executorService).getCorePoolSize(); i++) {
+            executorService.submit(this::processTasks);
+        }
+    }
+
+    private void processTasks() {
+        try {
+            System.out.println("Thread started");
+            while (true) {
+                MediaDownloadTask task = queue.takeTask();
+                System.out.println("Status UUID " + task.getStatus().getUuid().toString());
+                StatusEntity status = task.getStatus();
+
+                System.out.println(status.getUuid().toString());
+
+                // Implement the download logic here
+                try {
+                    
+                status.media.add(mapFields(of("status", status), importMedia(task.getMedia())));
+
+					if (status.media.get(0).description != null) {
+						// status.exceptions.add(new ParseException("Image scaled down (4th column)"));
+						status.media.get(0).description = null;
+					}
+
+					if (task.getDescription() != null) {
+						if (task.getDescription().length() > 1500) {
+							// status.exceptions.add(new ParseException("Image caption too long (5th column)", number));
+						} else {
+							status.media.get(0).description = task.getDescription();
+						}
+					}
+                
+                statusService.save(status);
+
+                System.out.println("Added media to download for status " + status.getUuid());
+                
+                } catch (Exception exception) {
+                    // TODO: change this number thing here (errorOffset)
+                    status.exceptions.add(new ParseException("Image not usable", 1));
+                }
+                
+                TimeUnit.MILLISECONDS.sleep(AUTODONE_DOWNLOADRATELIMIT);
+
+            }
+        } catch (InterruptedException e) {
+            System.out.println("Thread interrupted");
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public void stop() {
+        executorService.shutdownNow();
+    }
+
+    public MediaEntity importMedia(String url) throws Exception {
+		var media = new MediaEntity();
+		var request = new URL(url).openConnection();
+
+		media.contentType = request.getContentType();
+
+		if (request.getContentLength() < 1024000) {
+			media.file = request.getInputStream().readAllBytes();
+		} else {
+			var buffer = new ByteArrayOutputStream();
+			var source = read(request.getInputStream());
+
+			var scaleX = source.getWidth();
+			var scaleY = source.getHeight();
+
+			if (scaleX > AUTODONE_IMG_SIZE_X) {
+				scaleX = AUTODONE_IMG_SIZE_X;
+				scaleY = (scaleX * source.getHeight()) / source.getWidth();
+			}
+
+			if (scaleY > AUTODONE_IMG_SIZE_Y) {
+				scaleY = AUTODONE_IMG_SIZE_Y;
+				scaleX = (scaleY * source.getWidth()) / source.getHeight();
+			}
+
+			var target = new BufferedImage(scaleX, scaleY, TYPE_INT_ARGB);
+			var scaled = source.getScaledInstance(scaleX, scaleY, SCALE_FAST);
+			target.getGraphics().drawImage(scaled, 0, 0, null, null);
+			write(target, AUTODONE_IMG_FORMAT, buffer);
+
+			media.description = "Scaled down from original";
+			media.file = buffer.toByteArray();
+		}
+
+		return media;
+	}
+}

--- a/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadExecutor.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadExecutor.java
@@ -4,6 +4,8 @@ import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_FORMAT;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_SIZE_X;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_SIZE_Y;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_DOWNLOADRATELIMIT;
+import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_DOWNLOADTHREADPOOL;
+
 
 import java.util.concurrent.PriorityBlockingQueue;
 
@@ -42,7 +44,7 @@ public class MediaDownloadExecutor {
     @Autowired()
     public MediaDownloadExecutor(MediaDownloadQueue queue) {
         this.queue = queue.getQueue();
-        this.executorService = Executors.newFixedThreadPool(1);
+        this.executorService = Executors.newFixedThreadPool(AUTODONE_DOWNLOADTHREADPOOL);
         System.out.println("Created executor service with 1 threads");
         System.out.println("MediaDownloadExecutor queue instance: " + System.identityHashCode(this.queue));
 
@@ -57,23 +59,15 @@ public class MediaDownloadExecutor {
 
     private void processTasks() {
         try {
-            System.out.println("Thread started");
+            System.out.println("Thread started with id: " + Thread.currentThread().getId());
             while (true) {
-                System.out.println("Taking task from queue:" + queue.size());
-                System.out.println("MediaDownloadExecutor queue instance: " + System.identityHashCode(queue));
                 MediaDownloadTask task = queue.take();
-                System.out.println("Downloading media for Time" + task.getStatus().getDate());
                 MediaEntity downloadMedia = importMedia(task.getMedia().getUrl());
-                System.out.println("Finished download media: " + task.getMedia().getUrl());
-                System.out.println("Download media file: " + downloadMedia.file.length);
 
-                System.out.println("Getting media from database: " + task.getMedia().getUuid().toString());
                 MediaEntity media = mediaService.getAny(task.getMedia().getUuid());
-                System.out.println("Got media from database: " + media.getUuid().toString());
 
                 media.file = downloadMedia.file;
 
-                System.out.println("media file: " + media.file.length);
 
                 media.contentType = downloadMedia.contentType;
                 if (downloadMedia.description != null) {
@@ -81,11 +75,8 @@ public class MediaDownloadExecutor {
                 }
                 
                 mediaService.save(media);
-                System.out.println("Saved media: " + media.getUuid().toString());
 
-                System.out.println("Thread sleeping");
                 TimeUnit.MILLISECONDS.sleep(AUTODONE_DOWNLOADRATELIMIT);
-                System.out.println("Thread continue");
 
             }
         } catch (InterruptedException e) {
@@ -100,7 +91,6 @@ public class MediaDownloadExecutor {
 
     public MediaEntity importMedia(String url) {
         try {
-            System.out.println("Downloading media: " + url);
             var media = new MediaEntity();
             var request = new URL(url).openConnection();
 

--- a/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadExecutor.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadExecutor.java
@@ -4,8 +4,13 @@ import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_FORMAT;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_SIZE_X;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_IMG_SIZE_Y;
 import static de.uoc.dh.idh.autodone.config.AutodoneConfig.AUTODONE_DOWNLOADRATELIMIT;
+import static de.uoc.dh.idh.autodone.utils.ObjectUtils.FORCE;
 import static de.uoc.dh.idh.autodone.utils.ObjectUtils.mapFields;
 
+import java.util.concurrent.PriorityBlockingQueue;
+
+
+import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -14,33 +19,38 @@ import java.util.concurrent.TimeUnit;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
 import static java.awt.Image.SCALE_FAST;
 import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
 import static java.util.Map.of;
 import static javax.imageio.ImageIO.read;
 import static javax.imageio.ImageIO.write;
+
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.net.URL;
 import java.text.ParseException;
+
 import de.uoc.dh.idh.autodone.entities.MediaEntity;
 import de.uoc.dh.idh.autodone.entities.StatusEntity;
 
 
-
-
 @Component
 public class MediaDownloadExecutor {
-    private final MediaDownloadQueue queue;
+    private final PriorityBlockingQueue<MediaDownloadTask> queue;
     private final ExecutorService executorService;
-    @Autowired()
-	private StatusService statusService;
+
+    @Autowired
+    private StatusService statusService;
+
 
     @Autowired
     public MediaDownloadExecutor(MediaDownloadQueue queue) {
-        this.queue = queue;
-        this.executorService = Executors.newFixedThreadPool(5); // Adjust thread count as needed
-        System.out.println("Created executor service with 5 threads");
+        this.queue = queue.getQueue();
+        this.executorService = Executors.newFixedThreadPool(1);
+        System.out.println("Created executor service with 1 threads");
+        System.out.println("MediaDownloadExecutor queue instance: " + System.identityHashCode(this.queue));
+
     }
 
     @PostConstruct
@@ -54,39 +64,33 @@ public class MediaDownloadExecutor {
         try {
             System.out.println("Thread started");
             while (true) {
-                MediaDownloadTask task = queue.takeTask();
-                System.out.println("Status UUID " + task.getStatus().getUuid().toString());
+                System.out.println("Attempting to take task from queue");
+                MediaDownloadTask task = queue.take();
+                System.out.println("Took task from queue : " + task.getDescription());
+
+                System.out.println("Processing task: " + task.getDescription());
+
                 StatusEntity status = task.getStatus();
 
-                System.out.println(status.getUuid().toString());
-
-                // Implement the download logic here
-                try {
-                    
                 status.media.add(mapFields(of("status", status), importMedia(task.getMedia())));
 
-					if (status.media.get(0).description != null) {
-						// status.exceptions.add(new ParseException("Image scaled down (4th column)"));
-						status.media.get(0).description = null;
-					}
+                if (status.media.get(0).description != null) {
+                    // status.exceptions.add(new ParseException("Image scaled down (4th column)"));
+                    status.media.get(0).description = null;
+                }
 
-					if (task.getDescription() != null) {
-						if (task.getDescription().length() > 1500) {
-							// status.exceptions.add(new ParseException("Image caption too long (5th column)", number));
-						} else {
-							status.media.get(0).description = task.getDescription();
-						}
-					}
-                
-                statusService.save(status);
+                if (task.getDescription() != null) {
+                    if (task.getDescription().length() > 1500) {
+                        // status.exceptions.add(new ParseException("Image caption too long (5th column)", number));
+                    } else {
+                        System.out.println("Setting description for media");
+                        status.media.get(0).description = task.getDescription();
+                    }
+                }
 
                 System.out.println("Added media to download for status " + status.getUuid());
-                
-                } catch (Exception exception) {
-                    // TODO: change this number thing here (errorOffset)
-                    status.exceptions.add(new ParseException("Image not usable", 1));
-                }
-                
+
+
                 TimeUnit.MILLISECONDS.sleep(AUTODONE_DOWNLOADRATELIMIT);
 
             }
@@ -100,40 +104,47 @@ public class MediaDownloadExecutor {
         executorService.shutdownNow();
     }
 
-    public MediaEntity importMedia(String url) throws Exception {
-		var media = new MediaEntity();
-		var request = new URL(url).openConnection();
+    public MediaEntity importMedia(String url) {
+        try {
+            System.out.println("Downloading media");
+            var media = new MediaEntity();
+            var request = new URL(url).openConnection();
 
-		media.contentType = request.getContentType();
+            media.contentType = request.getContentType();
 
-		if (request.getContentLength() < 1024000) {
-			media.file = request.getInputStream().readAllBytes();
-		} else {
-			var buffer = new ByteArrayOutputStream();
-			var source = read(request.getInputStream());
+            if (request.getContentLength() < 1024000) {
+                media.file = request.getInputStream().readAllBytes();
+            } else {
+                var buffer = new ByteArrayOutputStream();
+                var source = read(request.getInputStream());
 
-			var scaleX = source.getWidth();
-			var scaleY = source.getHeight();
+                var scaleX = source.getWidth();
+                var scaleY = source.getHeight();
 
-			if (scaleX > AUTODONE_IMG_SIZE_X) {
-				scaleX = AUTODONE_IMG_SIZE_X;
-				scaleY = (scaleX * source.getHeight()) / source.getWidth();
-			}
+                if (scaleX > AUTODONE_IMG_SIZE_X) {
+                    scaleX = AUTODONE_IMG_SIZE_X;
+                    scaleY = (scaleX * source.getHeight()) / source.getWidth();
+                }
 
-			if (scaleY > AUTODONE_IMG_SIZE_Y) {
-				scaleY = AUTODONE_IMG_SIZE_Y;
-				scaleX = (scaleY * source.getWidth()) / source.getHeight();
-			}
+                if (scaleY > AUTODONE_IMG_SIZE_Y) {
+                    scaleY = AUTODONE_IMG_SIZE_Y;
+                    scaleX = (scaleY * source.getWidth()) / source.getHeight();
+                }
 
-			var target = new BufferedImage(scaleX, scaleY, TYPE_INT_ARGB);
-			var scaled = source.getScaledInstance(scaleX, scaleY, SCALE_FAST);
-			target.getGraphics().drawImage(scaled, 0, 0, null, null);
-			write(target, AUTODONE_IMG_FORMAT, buffer);
+                var target = new BufferedImage(scaleX, scaleY, TYPE_INT_ARGB);
+                var scaled = source.getScaledInstance(scaleX, scaleY, SCALE_FAST);
+                target.getGraphics().drawImage(scaled, 0, 0, null, null);
+                write(target, AUTODONE_IMG_FORMAT, buffer);
 
-			media.description = "Scaled down from original";
-			media.file = buffer.toByteArray();
-		}
+                media.description = "Scaled down from original";
+                media.file = buffer.toByteArray();
+            }
 
-		return media;
-	}
+            return media;
+
+        } catch (IOException e) {
+            System.out.println("Io Exception" + e.getMessage());
+            return null;
+        }
+    }
 }

--- a/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadQueue.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadQueue.java
@@ -1,6 +1,7 @@
 package de.uoc.dh.idh.autodone.services;
 
 import org.springframework.stereotype.Component;
+
 import java.util.concurrent.PriorityBlockingQueue;
 
 @Component
@@ -10,13 +11,23 @@ public class MediaDownloadQueue {
     public void addTask(MediaDownloadTask task) {
         queue.add(task);
         System.out.println("Added task: " + task.getDescription());
+        System.out.println("Queue size after adding task: " + queue.size());
+        System.out.println("MediaDownloadQueue instance: " + System.identityHashCode(this));
+
     }
 
     public MediaDownloadTask takeTask() throws InterruptedException {
-        return queue.take();
+        System.out.println("MediaDownloadQueue instance: " + System.identityHashCode(this));
+        MediaDownloadTask task = queue.take();
+        System.out.println("Queue size after taking task: " + queue.size());
+        return task;
     }
 
     public void clear() {
         queue.clear();
+    }
+
+    public PriorityBlockingQueue<MediaDownloadTask> getQueue() {
+        return queue;
     }
 }

--- a/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadQueue.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadQueue.java
@@ -10,16 +10,11 @@ public class MediaDownloadQueue {
 
     public void addTask(MediaDownloadTask task) {
         queue.add(task);
-        System.out.println("Added task: " + task.getDescription());
-        System.out.println("Queue size after adding task: " + queue.size());
         System.out.println("MediaDownloadQueue instance: " + System.identityHashCode(this));
-
     }
 
     public MediaDownloadTask takeTask() throws InterruptedException {
-        System.out.println("MediaDownloadQueue instance: " + System.identityHashCode(this));
         MediaDownloadTask task = queue.take();
-        System.out.println("Queue size after taking task: " + queue.size());
         return task;
     }
 

--- a/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadQueue.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadQueue.java
@@ -1,0 +1,22 @@
+package de.uoc.dh.idh.autodone.services;
+
+import org.springframework.stereotype.Component;
+import java.util.concurrent.PriorityBlockingQueue;
+
+@Component
+public class MediaDownloadQueue {
+    private final PriorityBlockingQueue<MediaDownloadTask> queue = new PriorityBlockingQueue<>();
+
+    public void addTask(MediaDownloadTask task) {
+        queue.add(task);
+        System.out.println("Added task: " + task.getDescription());
+    }
+
+    public MediaDownloadTask takeTask() throws InterruptedException {
+        return queue.take();
+    }
+
+    public void clear() {
+        queue.clear();
+    }
+}

--- a/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadTask.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadTask.java
@@ -1,32 +1,23 @@
 package de.uoc.dh.idh.autodone.services;
 
+import de.uoc.dh.idh.autodone.entities.MediaEntity;
 import de.uoc.dh.idh.autodone.entities.StatusEntity;
 
 public class MediaDownloadTask implements Comparable<MediaDownloadTask> {
-    private final String media;
+    private final MediaEntity media;
     private final StatusEntity status;
-    private final String description;
 
-    public MediaDownloadTask(String media, StatusEntity status, String description) {
+    public MediaDownloadTask(MediaEntity media, StatusEntity status) {
         this.media = media;
         this.status = status;
-        this.description = description;
     }
 
-    public MediaDownloadTask(String media, StatusEntity status) {
-        this(media, status, null);
-    }
-
-    public String getMedia() {
+    public MediaEntity getMedia() {
         return media;
     }
 
     public StatusEntity getStatus() {
         return status;
-    }
-
-    public String getDescription() {
-        return description;
     }
 
     @Override

--- a/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadTask.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/MediaDownloadTask.java
@@ -1,0 +1,36 @@
+package de.uoc.dh.idh.autodone.services;
+
+import de.uoc.dh.idh.autodone.entities.StatusEntity;
+
+public class MediaDownloadTask implements Comparable<MediaDownloadTask> {
+    private final String media;
+    private final StatusEntity status;
+    private final String description;
+
+    public MediaDownloadTask(String media, StatusEntity status, String description) {
+        this.media = media;
+        this.status = status;
+        this.description = description;
+    }
+
+    public MediaDownloadTask(String media, StatusEntity status) {
+        this(media, status, null);
+    }
+
+    public String getMedia() {
+        return media;
+    }
+
+    public StatusEntity getStatus() {
+        return status;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public int compareTo(MediaDownloadTask other) {
+        return this.status.getDate().compareTo(other.getStatus().getDate());
+    }
+}

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -25,7 +25,9 @@ autodone.img.size.y=512
 autodone.pagination=20
 autodone.scheduling=30
 autodone.threadpool=5
+
 autodone.downloadratelimit=1000
+autodone.downloadthreadpool=2
 
 ############
 # MASTODON #

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -25,6 +25,7 @@ autodone.img.size.y=512
 autodone.pagination=20
 autodone.scheduling=30
 autodone.threadpool=5
+autodone.downloadratelimit=1000
 
 ############
 # MASTODON #

--- a/src/main/resources/templates/forms/media.html
+++ b/src/main/resources/templates/forms/media.html
@@ -43,6 +43,20 @@
             <label class="form-label">Description for the attached Media</label>
           </div>
         </div>
+        <div th:if="*{file}">
+          <label class="form-label fw-bold" for="downloadStatus">Download Status</label>
+          <div class="form-floating">
+            <p class="form-control-plaintext">File available</p>
+            <label class="form-label">File Download Status</label>
+          </div>
+        </div>
+        <div th:unless="*{file}">
+          <label class="form-label fw-bold" for="downloadStatus">Download Status</label>
+          <div class="form-floating">
+            <p class="form-control-plaintext">File not available</p>
+            <label class="form-label">File Download Status</label>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/main/resources/templates/tables/media.html
+++ b/src/main/resources/templates/tables/media.html
@@ -6,22 +6,28 @@
       <div class="card-body p-0">
         <p th:if="*{description}" th:text="*{description}" class="card-text p-3"></p>
       </div>
-
-      <div class="card-footer d-flex justify-content-end">
-        <a th:href="@{/media(uuid=*{uuid})}" class="btn btn-sm btn-outline-primary me-1">
-          <i class="bi bi-eye-fill"></i>
-        </a>
-        <th:block th:if="${#path} == '/media'">
-          <a th:href="@{/status(uuid=*{status.uuid})}" class="btn btn-sm btn-outline-secondary me-1">
-            <i class="bi bi-list"></i>
+      
+      <div class="card-footer d-flex justify-content-between align-items-center">
+        <div>
+            <i th:classappend="${media.file} ? 'bi bi-check-circle-fill text-success' : 'bi bi-check-circle-fill text-warning'"
+             th:title="${media.file} ? 'Downloaded' : 'Waiting for download'"></i>
+        </div>
+        <div>
+          <a th:href="@{/media(uuid=*{uuid})}" class="btn btn-sm btn-outline-primary me-1">
+        <i class="bi bi-eye-fill"></i>
           </a>
-        </th:block>
-        <form th:action="@{/media}" th:method="post" class="d-inline-block m-0">
-          <input th:value="*{uuid}" name="uuid" type="hidden">
-          <button class="btn btn-sm btn-outline-danger" name="_method" value="delete">
-            <i class="bi bi-trash-fill"></i>
-          </button>
-        </form>
+          <th:block th:if="${#path} == '/media'">
+        <a th:href="@{/status(uuid=*{status.uuid})}" class="btn btn-sm btn-outline-secondary me-1">
+          <i class="bi bi-list"></i>
+        </a>
+          </th:block>
+          <form th:action="@{/media}" th:method="post" class="d-inline-block m-0">
+        <input th:value="*{uuid}" name="uuid" type="hidden">
+        <button class="btn btn-sm btn-outline-danger" name="_method" value="delete">
+          <i class="bi bi-trash-fill"></i>
+        </button>
+          </form>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Kein echtes Rate-Limiting, sondern eine Änderung der Strategie für den Download von Mediendateien

_Disclaimer: Dies ist kein echtes Einschränken der Download-Rate. Vielmehr wurde die Download-Strategie umgestellt, sodass die Mediendateien nicht mehr direkt beim Importieren einer Gruppe heruntergeladen werden. Stattdessen werden die Dateien erst nach der Erstellung der Gruppe jeder für sich einer Download-Warteschlange hinzugefügt. Dadurch wird der Importprozess wesentlich schneller, und der Download erfolgt im Hintergrund. Die **Geschwindigkeit** mit der runtergeladen wird, kann kontrolliert werden in dem zwischen jedem download eine pause eingelegt wird._

Dies ändert, dass die Mediendateien beim Import von .tsv-Dateien nicht mehr direkt geladen werden. Stattdessen wird nach dem Import, sobald die Gruppe erstellt wurde, für jede Mediendatei ein MediaDownloadTask erstellt und einer PriorityBlockingQueue hinzugefügt.
Diese PriorityBlockingQueue ist automatisch nach dem Datum des Posts sortiert, zu dem die Mediendatei gehört. Dadurch werden zuerst die Posts heruntergeladen, die vermutlich früher veröffentlicht werden sollen.

Die Queue wird mithilfe eines oder mehrerer unendlich laufender Threads abgearbeitet (der Threadpool ist über die application.properties konfigurierbar). Nach dem Download einer Mediendatei wartet der Thread eine festgelegte Anzahl an Millisekunden (ebenfalls in den application.properties einstellbar), bevor er das nächste Bild herunterlädt.

Beim manuellen Hinzufügen von Medien wurde nichts verändert; dies geschieht weiterhin direkt beim Hochladen eines Bildes.

**Dinge zu beachten:**

1. Ich war mir nicht ganz sicher, wo ich die Java-Klassen für den Media-Download einsortieren sollte. Daher habe ich sie vorerst im services-Ordner abgelegt.
2. Da die Tasks nicht in der Datenbank gespeichert werden, verschwinden sie, falls autodone offline geht.
3. Die Download-Rate wird nicht direkt limitiert. Stattdessen wird nach dem Download eines Bildes eine Wartezeit eingehalten, bevor der Thread das nächste Bild bearbeitet.