### PR TITLE
SSRF Mitigation: Sanitise Image Import URLs

### DIFF
--- a/src/main/java/de/uoc/dh/idh/autodone/services/ImportService.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/services/ImportService.java
@@ -114,7 +114,11 @@ public class ImportService {
 
 			if (columns.length > 3) {
 				try {
-					status.media.add(mapFields(of("status", status), importMedia(columns[3])));
+					if (columns[3].matches("^https?://.+")) {
+						status.media.add(mapFields(of("status", status), importMedia(columns[3])));
+					} else {
+						throw new SecurityException("Illegal protocol");
+					}
 
 					if (status.media.get(0).description != null) {
 						status.exceptions.add(new ParseException("Image scaled down (4th column)", number));
@@ -143,7 +147,9 @@ public class ImportService {
 		var media = new MediaEntity();
 		var request = new URL(url).openConnection();
 
-		media.contentType = request.getContentType();
+		if (!(media.contentType = request.getContentType()).startsWith("image/")) {
+			throw new IllegalArgumentException("Not an image file");
+		}
 
 		if (request.getContentLength() < 1024000) {
 			media.file = request.getInputStream().readAllBytes();


### PR DESCRIPTION
This pull request mitigates an attack vector on autodone found by @thunze

> A Server-Side Request Forgery (SSRF) vulnerability has been identified in the Autodone software [...]. This vulnerability allows malicious users [...]:
> - Arbitrary file reads from the system hosting Autodone [...]
> - Requests to arbitrary URLs, including internal services accessible from the Autodone server [...]

To mitigate those risks, URLs will now have to conform to the `http[s]` scheme and the mime-type of the server response has to start with `image/`. This disallows file system access and access to any non-image resources but **does not** limit access to the internal network autodone is hosted within.

Thank You, @thunze, for bringing this security issue to our attention!