### PR TITLE
Fix Mastodon API typing

### DIFF
--- a/src/main/java/de/uoc/dh/idh/autodone/controller/GroupController.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/controller/GroupController.java
@@ -85,7 +85,7 @@ public class GroupController {
 		var group = new GroupEntity();
 
 		if (form.containsKey("uuid")) {
-			group = groupService.getOne((String) form.get("uuid"));
+			group = groupService.getOne(form.get("uuid"));
 		}
 
 		var save = groupService.save(mapFields(form, group, FORCE));

--- a/src/main/java/de/uoc/dh/idh/autodone/entities/ServerEntity.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/entities/ServerEntity.java
@@ -53,7 +53,7 @@ public class ServerEntity {
 	public String description;
 
 	@Transient()
-	public List<Map<String, String>> rules;
+	public List<Map<String, Object>> rules;
 
 	@Transient()
 	public Map<String, Object> thumbnail;

--- a/src/main/java/de/uoc/dh/idh/autodone/utils/ProjectUtils.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/utils/ProjectUtils.java
@@ -17,7 +17,6 @@ public class ProjectUtils {
 	private ProjectUtils(BuildProperties buildProperties, EntityManager entityManager) throws Exception {
 		var file = "META-INF/maven/" + buildProperties.getGroup() + "/" + buildProperties.getArtifact() + "/pom.xml";
 		projectModel = new MavenXpp3Reader().read(getClass().getClassLoader().getResourceAsStream(file));
-
 	}
 
 }


### PR DESCRIPTION
This pull request changes the deserialisation of the [Mastodon Instance API](https://docs.joinmastodon.org/methods/instance/#rules) `rules` object from `Map<String, String>` to `Map<String, Object>`, as it now may contain a `translations` field, mapping to a JSON object with key/value pairs (`"lang": "translated rule string"`).